### PR TITLE
Add femto bolt camera mesh

### DIFF
--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -28,7 +28,7 @@
 #include <vector>
 #include <atomic>
 #include <opencv2/opencv.hpp>
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 #include <tf2_ros/static_transform_broadcaster.h>

--- a/orbbec_camera/include/orbbec_camera/ros_param_backend.h
+++ b/orbbec_camera/include/orbbec_camera/ros_param_backend.h
@@ -23,7 +23,7 @@ class ParametersBackend {
   explicit ParametersBackend(rclcpp::Node* node);
   ~ParametersBackend();
   void addOnSetParametersCallback(
-      rclcpp::node_interfaces::NodeParametersInterface::OnParametersSetCallbackType callback);
+      rclcpp::node_interfaces::NodeParametersInterface::OnSetParametersCallbackType callback);
 
  private:
   rclcpp::Node* node_;

--- a/orbbec_camera/src/d2c_viewer.cpp
+++ b/orbbec_camera/src/d2c_viewer.cpp
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *******************************************************************************/
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.hpp>
 #include <sensor_msgs/image_encodings.hpp>
 
 #include <opencv2/opencv.hpp>

--- a/orbbec_camera/src/ros_param_backend.cpp
+++ b/orbbec_camera/src/ros_param_backend.cpp
@@ -28,7 +28,7 @@ ParametersBackend::~ParametersBackend() {
 }
 
 void ParametersBackend::addOnSetParametersCallback(
-    rclcpp::node_interfaces::NodeParametersInterface::OnParametersSetCallbackType callback) {
+    rclcpp::node_interfaces::NodeParametersInterface::OnSetParametersCallbackType callback) {
   ros_callback_ = node_->add_on_set_parameters_callback(callback);
 }
 

--- a/orbbec_description/CMakeLists.txt
+++ b/orbbec_description/CMakeLists.txt
@@ -22,4 +22,7 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
+install(DIRECTORY meshes 
+  DESTINATION share/${PROJECT_NAME})
+
 ament_package()


### PR DESCRIPTION
- Update CMakeLists to export the mesh models
- Fix header includes for ROS Iron
- Add the femto bolt camera model (exported from https://github.com/orbbec/OrbbecHardware)