### PR TITLE
fix CMakeLists.txt at orbbec_description

### DIFF
--- a/orbbec_description/CMakeLists.txt
+++ b/orbbec_description/CMakeLists.txt
@@ -6,8 +6,7 @@ find_package(ament_cmake REQUIRED)
 # Install files
 install(DIRECTORY 
         launch 
-        meshes 
-        rviz 
+        meshes
         urdf
         DESTINATION share/${PROJECT_NAME})
 


### PR DESCRIPTION
fixes build error caused by referencing a non existent rviz directory.
not sure though why it even ended up in there