### PR TITLE
Add support for multiple cameras in multiple robots

### DIFF
--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -352,6 +352,7 @@ class OBCameraNode {
   std::unique_ptr<ob::Pipeline> pipeline_ = nullptr;
   std::unique_ptr<ob::Pipeline> imuPipeline_ = nullptr;
   std::atomic_bool pipeline_started_{false};
+  std::string prefix_ = "";
   std::string camera_name_ = "camera";
   const std::string imu_optical_frame_id_ = "camera_gyro_optical_frame";
   const std::string imu_frame_id_ = "camera_gyro_frame";

--- a/orbbec_camera/launch/astra.launch.py
+++ b/orbbec_camera/launch/astra.launch.py
@@ -12,6 +12,7 @@ from launch_ros.descriptions import ComposableNode
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('depth_registration', default_value='false'),
         DeclareLaunchArgument('serial_number', default_value=''),
@@ -99,14 +100,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -119,7 +120,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/astra2.launch.py
+++ b/orbbec_camera/launch/astra2.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('depth_registration', default_value='false'),
         DeclareLaunchArgument('serial_number', default_value=''),
@@ -107,14 +108,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -127,7 +128,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/astra_adv.launch.py
+++ b/orbbec_camera/launch/astra_adv.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('depth_registration', default_value='false'),
         DeclareLaunchArgument('serial_number', default_value=''),
@@ -99,14 +100,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -119,7 +120,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/astra_embedded_s.launch.py
+++ b/orbbec_camera/launch/astra_embedded_s.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('depth_registration', default_value='false'),
         DeclareLaunchArgument('serial_number', default_value=''),
@@ -99,14 +100,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -119,7 +120,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/astra_pro2.launch.py
+++ b/orbbec_camera/launch/astra_pro2.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('depth_registration', default_value='false'),
         DeclareLaunchArgument('serial_number', default_value=''),
@@ -99,14 +100,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -119,7 +120,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/astra_stereo_u3.launch.py
+++ b/orbbec_camera/launch/astra_stereo_u3.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('depth_registration', default_value='false'),
         DeclareLaunchArgument('serial_number', default_value=''),
@@ -99,14 +100,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -119,7 +120,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/dabai.launch.py
+++ b/orbbec_camera/launch/dabai.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('depth_registration', default_value='false'),
         DeclareLaunchArgument('serial_number', default_value=''),
@@ -99,14 +100,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -119,7 +120,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/dabai_d1.launch.py
+++ b/orbbec_camera/launch/dabai_d1.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('serial_number', default_value=''),
         DeclareLaunchArgument('usb_port', default_value=''),
@@ -83,14 +84,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -103,7 +104,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/dabai_dcl.py
+++ b/orbbec_camera/launch/dabai_dcl.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('depth_registration', default_value='false'),
         DeclareLaunchArgument('serial_number', default_value=''),
@@ -120,14 +121,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -140,7 +141,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/dabai_dcw.launch.py
+++ b/orbbec_camera/launch/dabai_dcw.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('depth_registration', default_value='false'),
         DeclareLaunchArgument('serial_number', default_value=''),
@@ -99,14 +100,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -119,7 +120,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/dabai_dcw2.launch.py
+++ b/orbbec_camera/launch/dabai_dcw2.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('depth_registration', default_value='false'),
         DeclareLaunchArgument('serial_number', default_value=''),
@@ -107,14 +108,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -127,7 +128,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/dabai_dw.launch.py
+++ b/orbbec_camera/launch/dabai_dw.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('serial_number', default_value=''),
         DeclareLaunchArgument('usb_port', default_value=''),
@@ -82,14 +83,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -102,7 +103,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/dabai_dw2.launch.py
+++ b/orbbec_camera/launch/dabai_dw2.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('serial_number', default_value=''),
         DeclareLaunchArgument('usb_port', default_value=''),
@@ -82,14 +83,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -102,7 +103,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/dabai_max.launch.py
+++ b/orbbec_camera/launch/dabai_max.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('serial_number', default_value=''),
         DeclareLaunchArgument('usb_port', default_value=''),
@@ -84,14 +85,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -104,7 +105,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/dabai_max_pro.launch.py
+++ b/orbbec_camera/launch/dabai_max_pro.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('depth_registration', default_value='false'),
         DeclareLaunchArgument('serial_number', default_value=''),
@@ -100,14 +101,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -120,7 +121,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/dabai_pro.launch.py
+++ b/orbbec_camera/launch/dabai_pro.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('serial_number', default_value=''),
         DeclareLaunchArgument('usb_port', default_value=''),
@@ -82,14 +83,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -102,7 +103,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/deeya.launch.py
+++ b/orbbec_camera/launch/deeya.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('depth_registration', default_value='false'),
         DeclareLaunchArgument('serial_number', default_value=''),
@@ -97,14 +98,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -117,7 +118,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/femto.launch.py
+++ b/orbbec_camera/launch/femto.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('depth_registration', default_value='false'),
         DeclareLaunchArgument('serial_number', default_value=''),
@@ -108,14 +109,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -128,7 +129,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/femto_bolt.launch.py
+++ b/orbbec_camera/launch/femto_bolt.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('depth_registration', default_value='false'),
         DeclareLaunchArgument('serial_number', default_value=''),
@@ -115,14 +116,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -135,7 +136,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/femto_mega.launch.py
+++ b/orbbec_camera/launch/femto_mega.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('depth_registration', default_value='false'),
         DeclareLaunchArgument('serial_number', default_value=''),
@@ -123,14 +124,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -143,7 +144,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/gemini2.launch.py
+++ b/orbbec_camera/launch/gemini2.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('depth_registration', default_value='false'),
         DeclareLaunchArgument('serial_number', default_value=''),
@@ -121,14 +122,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -141,7 +142,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/gemini2L.launch.py
+++ b/orbbec_camera/launch/gemini2L.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('depth_registration', default_value='false'),
         DeclareLaunchArgument('serial_number', default_value=''),
@@ -122,14 +123,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -142,7 +143,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/gemini2VL.launch.py
+++ b/orbbec_camera/launch/gemini2VL.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('depth_registration', default_value='false'),
         DeclareLaunchArgument('serial_number', default_value=''),
@@ -114,14 +115,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -134,7 +135,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/gemini2XL.launch.py
+++ b/orbbec_camera/launch/gemini2XL.launch.py
@@ -11,6 +11,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('depth_registration', default_value='false'),
         DeclareLaunchArgument('serial_number', default_value=''),
@@ -130,14 +131,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -150,7 +151,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/gemini_330_series.launch.py
+++ b/orbbec_camera/launch/gemini_330_series.launch.py
@@ -51,6 +51,7 @@ def load_parameters(context, args):
 
 def generate_launch_description():
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('depth_registration', default_value='true'),
         DeclareLaunchArgument('serial_number', default_value=''),

--- a/orbbec_camera/launch/gemini_e.launch.py
+++ b/orbbec_camera/launch/gemini_e.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('depth_registration', default_value='false'),
         DeclareLaunchArgument('serial_number', default_value=''),
@@ -98,14 +99,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -118,7 +119,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/gemini_e_lite.launch.py
+++ b/orbbec_camera/launch/gemini_e_lite.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('serial_number', default_value=''),
         DeclareLaunchArgument('usb_port', default_value=''),
@@ -83,14 +84,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -103,7 +104,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/gemini_ew.launch.py
+++ b/orbbec_camera/launch/gemini_ew.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('depth_registration', default_value='false'),
         DeclareLaunchArgument('serial_number', default_value=''),
@@ -99,14 +100,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -119,7 +120,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/gemini_ew_lite.launch.py
+++ b/orbbec_camera/launch/gemini_ew_lite.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('serial_number', default_value=''),
         DeclareLaunchArgument('usb_port', default_value=''),
@@ -86,14 +87,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -106,7 +107,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/gemini_intra_process_demo_launch.py
+++ b/orbbec_camera/launch/gemini_intra_process_demo_launch.py
@@ -51,6 +51,7 @@ def load_parameters(context, args):
 
 def generate_launch_description():
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('depth_registration', default_value='true'),
         DeclareLaunchArgument('serial_number', default_value=''),

--- a/orbbec_camera/launch/gemini_uw.launch.py
+++ b/orbbec_camera/launch/gemini_uw.launch.py
@@ -12,6 +12,7 @@ import os
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('depth_registration', default_value='false'),
         DeclareLaunchArgument('serial_number', default_value=''),
@@ -100,14 +101,14 @@ def generate_launch_description():
         compose_node = ComposableNode(
             package="orbbec_camera",
             plugin="orbbec_camera::OBCameraNodeDriver",
-            name=LaunchConfiguration("camera_name"),
-            namespace="",
+            name="orbbec_node_driver",
+            namespace=LaunchConfiguration("camera_name"),
             parameters=parameters,
         )
         # Define the ComposableNodeContainer
         container = ComposableNodeContainer(
-            name="camera_container",
-            namespace="",
+            name="container",
+            namespace=LaunchConfiguration("camera_name"),
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -120,7 +121,7 @@ def generate_launch_description():
             args
             + [
                 GroupAction(
-                    [PushRosNamespace(LaunchConfiguration("camera_name")), container]
+                    [PushRosNamespace(LaunchConfiguration("prefix")), container]
                 )
             ]
         )

--- a/orbbec_camera/launch/ob_camera.launch.py
+++ b/orbbec_camera/launch/ob_camera.launch.py
@@ -10,6 +10,7 @@ from launch_ros.descriptions import ComposableNode
 def generate_launch_description():
     # Declare arguments
     args = [
+        DeclareLaunchArgument('prefix', default_value=''),
         DeclareLaunchArgument('camera_name', default_value='camera'),
         DeclareLaunchArgument('depth_registration', default_value='false'),
         DeclareLaunchArgument('serial_number', default_value=''),
@@ -74,14 +75,14 @@ def generate_launch_description():
     compose_node = ComposableNode(
         package='orbbec_camera',
         plugin='orbbec_camera::OBCameraNodeDriver',
-        name=LaunchConfiguration('camera_name'),
-        namespace='',
+        name="orbbec_node_driver",
+        namespace=LaunchConfiguration("camera_name"),
         parameters=parameters,
     )
     # Define the ComposableNodeContainer
     container = ComposableNodeContainer(
-        name='camera_container',
-        namespace='',
+        name="container",
+        namespace=LaunchConfiguration("camera_name"),
         package='rclcpp_components',
         executable='component_container',
         composable_node_descriptions=[

--- a/orbbec_camera/src/d2c_viewer.cpp
+++ b/orbbec_camera/src/d2c_viewer.cpp
@@ -30,9 +30,9 @@ D2CViewer::D2CViewer(rclcpp::Node* const node, rmw_qos_profile_t rgb_qos,
                      rmw_qos_profile_t depth_qos)
     : node_(node), logger_(rclcpp::get_logger("d2c_viewer")) {
   rgb_sub_ = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::Image>>(
-      node_, "color/image_raw", rgb_qos);
+      node_, "~/color/image_raw", rgb_qos);
   depth_sub_ = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::Image>>(
-      node_, "depth/image_raw", depth_qos);
+      node_, "~/depth/image_raw", depth_qos);
   sync_ = std::make_shared<message_filters::Synchronizer<MySyncPolicy>>(MySyncPolicy(10), *rgb_sub_,
                                                                         *depth_sub_);
   sync_->setMaxIntervalDuration(rclcpp::Duration::from_seconds(1.0));  // 1s
@@ -41,7 +41,7 @@ D2CViewer::D2CViewer(rclcpp::Node* const node, rmw_qos_profile_t rgb_qos,
   using std::placeholders::_2;
   sync_->registerCallback(std::bind(&D2CViewer::messageCallback, this, _1, _2));
   d2c_viewer_pub_ =
-      node_->create_publisher<sensor_msgs::msg::Image>("depth_to_color/image_raw", rclcpp::QoS(1));
+      node_->create_publisher<sensor_msgs::msg::Image>("~/depth_to_color/image_raw", rclcpp::QoS(1));
 }
 D2CViewer::~D2CViewer() = default;
 


### PR DESCRIPTION
Hello,

I realized that when using multiple robots with multiple cameras it wasn't possible to set a prefix. So I modified the the launch files and main code to support a prefix (example: robot1, robot2), maintaining backward compatibility if no prefix is set.

I tested the modifications using 2 femto bolts:

**Test with prefix:**
![frames_with_prefix](https://github.com/user-attachments/assets/68a1bc26-dc32-4576-8c22-2215be84f694)
![topics_with_prefix_removed](https://github.com/user-attachments/assets/e7d0a297-1fb1-4e5f-b0f1-a6773673845b)


**Test without prefix:**
![frames_without_prefix](https://github.com/user-attachments/assets/b37908c7-c480-4933-9e08-27a0560a7fa6)
![topics_without_prefix](https://github.com/user-attachments/assets/39b86738-297a-4d1f-8331-6e7e0ff07fc3)
