### PR TITLE
Remove undeclared and unused dependency

### DIFF
--- a/orbbec_camera/CMakeLists.txt
+++ b/orbbec_camera/CMakeLists.txt
@@ -40,7 +40,6 @@ set(dependencies
   std_msgs
   std_srvs
   tf2
-  tf2_eigen
   tf2_msgs
   tf2_ros
   tf2_sensor_msgs


### PR DESCRIPTION
When building this in a clean container and using `rosdep` to install dependencies, `tf2_eigen` ends up missing