### PR TITLE
Fixing ROS Rolling compilation (deprecated files throw error due to warning)

### DIFF
--- a/orbbec_camera/include/orbbec_camera/d2c_viewer.h
+++ b/orbbec_camera/include/orbbec_camera/d2c_viewer.h
@@ -14,10 +14,30 @@
 * limitations under the License.
 *******************************************************************************/
 #pragma once
+#if __has_include(<message_filters/subscriber.hpp>)
+#include <message_filters/subscriber.hpp>
+#else
 #include <message_filters/subscriber.h>
+#endif
+
+#if __has_include(<message_filters/sync_policies/approximate_time.hpp>)
+#include <message_filters/sync_policies/approximate_time.hpp>
+#else
 #include <message_filters/sync_policies/approximate_time.h>
+#endif
+
+#if __has_include(<message_filters/synchronizer.hpp>)
+#include <message_filters/synchronizer.hpp>
+#else
 #include <message_filters/synchronizer.h>
+#endif
+
+#if __has_include(<message_filters/time_synchronizer.hpp>)
+#include <message_filters/time_synchronizer.hpp>
+#else
 #include <message_filters/time_synchronizer.h>
+#endif
+
 #include <sensor_msgs/msg/image.hpp>
 #include <rclcpp/rclcpp.hpp>
 

--- a/orbbec_camera/tools/multi_save_rgbir.cpp
+++ b/orbbec_camera/tools/multi_save_rgbir.cpp
@@ -5,9 +5,24 @@
 #include <orbbec_camera/utils.h>
 #include "orbbec_camera/ob_camera_node.h"
 #include "orbbec_camera_msgs/msg/metadata.hpp"
+#if __has_include(<message_filters/subscriber.hpp>)
+#include <message_filters/subscriber.hpp>
+#else
 #include <message_filters/subscriber.h>
+#endif
+
+#if __has_include(<message_filters/sync_policies/approximate_time.hpp>)
+#include <message_filters/sync_policies/approximate_time.hpp>
+#else
 #include <message_filters/sync_policies/approximate_time.h>
+#endif
+
+#if __has_include(<message_filters/synchronizer.hpp>)
+#include <message_filters/synchronizer.hpp>
+#else
 #include <message_filters/synchronizer.h>
+#endif
+
 #include <std_msgs/msg/int32.hpp>
 #include <filesystem>
 #include <regex>

--- a/orbbec_camera/tools/ob_benchmark.cpp
+++ b/orbbec_camera/tools/ob_benchmark.cpp
@@ -3,9 +3,24 @@
 #include <orbbec_camera/ob_camera_node_driver.h>
 #include <orbbec_camera/utils.h>
 #include "orbbec_camera_msgs/msg/metadata.hpp"
+#if __has_include(<message_filters/subscriber.hpp>)
+#include <message_filters/subscriber.hpp>
+#else
 #include <message_filters/subscriber.h>
+#endif
+
+#if __has_include(<message_filters/sync_policies/approximate_time.hpp>)
+#include <message_filters/sync_policies/approximate_time.hpp>
+#else
 #include <message_filters/sync_policies/approximate_time.h>
+#endif
+
+#if __has_include(<message_filters/synchronizer.hpp>)
+#include <message_filters/synchronizer.hpp>
+#else
 #include <message_filters/synchronizer.h>
+#endif
+
 #include <filesystem>
 
 namespace orbbec_camera {

--- a/orbbec_camera/tools/start_benchmark.cpp
+++ b/orbbec_camera/tools/start_benchmark.cpp
@@ -3,9 +3,24 @@
 #include <orbbec_camera/ob_camera_node_driver.h>
 #include <orbbec_camera/utils.h>
 #include "orbbec_camera_msgs/msg/metadata.hpp"
+#if __has_include(<message_filters/subscriber.hpp>)
+#include <message_filters/subscriber.hpp>
+#else
 #include <message_filters/subscriber.h>
+#endif
+
+#if __has_include(<message_filters/sync_policies/approximate_time.hpp>)
+#include <message_filters/sync_policies/approximate_time.hpp>
+#else
 #include <message_filters/sync_policies/approximate_time.h>
+#endif
+
+#if __has_include(<message_filters/synchronizer.hpp>)
+#include <message_filters/synchronizer.hpp>
+#else
 #include <message_filters/synchronizer.h>
+#endif
+
 #include <filesystem>
 
 namespace orbbec_camera {


### PR DESCRIPTION
At ros rolling some files are going to be obsolete anytime soon:

> #include <message_filters/subscriber.h>
> #include <message_filters/sync_policies/approximate_time.h>
> #include <message_filters/synchronizer.h>

When compiling, they throw the following errors : 

> In file included from /home/xxxxxx/Documents/ros2_orbecc/src/OrbbecSDK_ROS2/orbbec_camera/include/orbbec_camera/d2c_viewer.h:19:
> /opt/ros/rolling/include/message_filters/message_filters/synchronizer.h:18:2: error: #warning This header is obsolete, please include message_filters/synchronizer.hpp instead [-Werror=cpp]
>    18 | #warning This header is obsolete, please include message_filters/synchronizer.hpp instead
>       |  ^~~~~~~
> In file included from /home/ctierno/Documents/ros2_orbecc/src/OrbbecSDK_ROS2/orbbec_camera/include/orbbec_camera/d2c_viewer.h:20:
> /opt/ros/rolling/include/message_filters/message_filters/time_synchronizer.h:18:2: error: #warning This header is obsolete, please include message_filters/time_synchronizer.hpp instead [-Werror=cpp]
>    18 | #warning This header is obsolete, please include message_filters/time_synchronizer.hpp instead

And as I am kind of a lazy person, and dont want to call:
`colcon build --cmake-args -DCMAKE_CXX_FLAGS="-w"`
everytime I need to reconfigure or erase the build folder. I've changed the includes to use the `#if __has_include`  tag