### PR TITLE
require 'orbbec_camera_msgs' version 2 or greater

### DIFF
--- a/orbbec_camera/package.xml
+++ b/orbbec_camera/package.xml
@@ -17,7 +17,7 @@
   <depend>rclcpp_components</depend>
   <depend>cv_bridge</depend>
   <depend>camera_info_manager</depend>
-  <depend>orbbec_camera_msgs</depend>
+  <depend version_gte="2">orbbec_camera_msgs</depend>
   <depend>builtin_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>


### PR DESCRIPTION
To prevent conflicts with v1 of the packages, make sure that the v2 branch depends on version 2 of the `orbbec_camera_msgs` package.