### PR TITLE
fix rotation matrix construction in column-major order

### DIFF
--- a/orbbec_camera/src/utils.cpp
+++ b/orbbec_camera/src/utils.cpp
@@ -199,10 +199,9 @@ void savePointsToPly(const std::shared_ptr<ob::Frame> &frame, const std::string 
 
 tf2::Quaternion rotationMatrixToQuaternion(const float rotation[9]) {
   Eigen::Matrix3f m;
-  // We need to be careful about the order, as RS2 rotation matrix is
-  // column-major, while Eigen::Matrix3f expects row-major.
-  m << rotation[0], rotation[1], rotation[2], rotation[3], rotation[4], rotation[5], rotation[6],
-      rotation[7], rotation[8];
+  m << rotation[0], rotation[3], rotation[6],
+       rotation[2], rotation[4], rotation[7],
+       rotation[3], rotation[5], rotation[8];
   Eigen::Quaternionf q(m);
   return {q.x(), q.y(), q.z(), q.w()};
 }


### PR DESCRIPTION
The function `rotationMatrixToQuaternion` incorrectly assumes and states that `Eigen::Matrix3f` is row-major, while the [Eigen documentation](https://libeigen.gitlab.io/eigen/docs-nightly/group__TopicStorageOrders.html) is explicit about this:

> If the storage order is not specified, then Eigen defaults to storing the entry in column-major. This is also the case if one of the convenience typedefs (Matrix3f, ArrayXXd, etc.) is used.
