### PR TITLE
Set `row_step` after resizing point cloud

### DIFF
--- a/orbbec_camera/src/ob_camera_node.cpp
+++ b/orbbec_camera/src/ob_camera_node.cpp
@@ -2774,6 +2774,7 @@ void OBCameraNode::publishDepthPointCloud(const std::shared_ptr<ob::FrameSet> &f
     point_cloud_msg->width = valid_count;
     point_cloud_msg->height = 1;
     modifier.resize(valid_count);
+    point_cloud_msg->row_step = point_cloud_msg->width * point_cloud_msg->point_step;
   }
   auto frame_timestamp = getFrameTimestampUs(depth_frame);
   auto timestamp = fromUsToROSTime(frame_timestamp);
@@ -2906,6 +2907,7 @@ void OBCameraNode::publishColoredPointCloud(const std::shared_ptr<ob::FrameSet> 
     point_cloud_msg->width = valid_count;
     point_cloud_msg->height = 1;
     modifier.resize(valid_count);
+    point_cloud_msg->row_step = point_cloud_msg->width * point_cloud_msg->point_step;
   }
   auto frame_timestamp = getFrameTimestampUs(depth_frame);
   std::string frame_id = optical_frame_id_[COLOR];


### PR DESCRIPTION
## Problem

I found `row_step` error in Foxglove Studio for point cloud topic from OrbbecSDK_ROS2@https://github.com/orbbec/OrbbecSDK_ROS2/commit/c0c14f538a9faf24319d246a27580308c17b1b5e  with ORBBEC Femto Boto, like the image below.

<img width="502" height="170" alt="Screenshot from 2026-03-09 08-13-02 (コピー)" src="https://github.com/user-attachments/assets/d642fd6d-1aa1-4eed-a553-938ff0942cf3" />

## Solution

Since `raw_step` was not updated after invalid points were removed, I added a line to update it.

And I had no error with the fixed version of `OrbbecSDK_ROS2`.
<img width="515" height="114" alt="image" src="https://github.com/user-attachments/assets/adf29b64-0ee3-4ad4-88dd-0a390c8970a5" />


> [!NOTE]
> `sensor_msgs::PointCloud2Modifier::resize` is a function often used to update `row_step`, but if consistency other than `row_step` has been achieved first, the `row_step` update will be skipped. https://github.com/ros2/common_interfaces/blob/jazzy/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.hpp#L127-L130
