### PR TITLE
fix: add missing comma after color_denoising_level in gemini2.launch.py

### DIFF
--- a/orbbec_camera/launch/gemini2.launch.py
+++ b/orbbec_camera/launch/gemini2.launch.py
@@ -44,7 +44,7 @@ def generate_launch_description():
         DeclareLaunchArgument("enable_color_auto_white_balance", default_value="true"),
         DeclareLaunchArgument("color_white_balance", default_value="-1"),
         DeclareLaunchArgument("color_brightness", default_value="-1"),
-        DeclareLaunchArgument('color_denoising_level', default_value='-1')
+        DeclareLaunchArgument('color_denoising_level', default_value='-1'),
         DeclareLaunchArgument('enable_color_decimation_filter', default_value='false'),
         DeclareLaunchArgument('color_decimation_filter_scale', default_value='-1'),
         DeclareLaunchArgument("depth_width", default_value="0"),


### PR DESCRIPTION
## Summary
Fixes a `SyntaxError` in `orbbec_camera/launch/gemini2.launch.py` caused by a
missing trailing comma after the `color_denoising_level` `DeclareLaunchArgument`.

## Reproduction
```bash
ros2 launch orbbec_camera gemini2.launch.py \
    namespace:=orbbec \
    color_width:=640 color_height:=480 color_fps:=30 \
    depth_width:=640 depth_height:=400 depth_fps:=30 \
    depth_registration:=true \
    enable_colored_point_cloud:=false
```

Before this fix:
SyntaxError: invalid syntax. Perhaps you forgot a comma? (gemini2.launch.py, line 47)

## Change
Added the missing comma on line 47 so the surrounding list literal parses correctly.

## Branch
v2-main
