### PR TITLE
add support for lyrical

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -12,8 +12,8 @@ assignees: ''
   - CPU model (e.g., `13th Gen Intel® Core™ i7-13700 × 24`, `NVIDIA Jetson Orin`)
   - Memory size (e.g., `16GB`, `32GB`)
   - GPU model if available (e.g., `NVIDIA RTX 3060`, `Integrated GPU`)
-- **Ubuntu Version**: Please provide the ubuntu version you are using (e.g., `ubuntu20.04`, `ubuntu22.04`, etc.)
-- **ROS Version**: Please provide the version of ROS you are using (e.g., `ROS Noetic`, `ROS 2 Foxy`, etc.)
+- **Ubuntu Version**: Please provide the ubuntu version you are using (e.g., `ubuntu22.04`, `ubuntu24.04`, etc.)
+- **ROS Version**: Please provide the version of ROS you are using (e.g., `ROS 2 Humble`, etc.)
 - **Camera Model**: Please provide the model of camera you are using (e.g., `Femto Bolt`, `Gemini 335`, etc.)
 - **Firmware Version**: Please provide the firmware version you are using.
 - **Branch**: Please provide the branch you are using (e.g., `main`, `v2-main`)

--- a/.github/workflows/colcon.yml
+++ b/.github/workflows/colcon.yml
@@ -1,0 +1,28 @@
+name: colcon
+
+on: [push, pull_request]
+
+jobs:
+  # build on Ubuntu docker images
+  build:
+    name: "${{ matrix.image }} (${{ matrix.ros }})"
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+            - {image: "ubuntu:22.04", ros: humble}
+            - {image: "ubuntu:24.04", ros: jazzy}
+
+    container:
+      image: ${{ matrix.image }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ros-tooling/setup-ros@v0.7
+
+      - uses: ros-tooling/action-ros-ci@v0.4
+        with:
+          target-ros2-distro: ${{ matrix.ros }}

--- a/.github/workflows/colcon.yml
+++ b/.github/workflows/colcon.yml
@@ -14,6 +14,7 @@ jobs:
         include:
             - {image: "ubuntu:22.04", ros: humble}
             - {image: "ubuntu:24.04", ros: jazzy}
+            - {image: "ubuntu:26.04", ros: lyrical}
 
     container:
       image: ${{ matrix.image }}

--- a/README.MD
+++ b/README.MD
@@ -12,9 +12,6 @@
 
 <!-- Labels: -->
   <!-- First row: -->
-  <a href="https://docs.ros.org/en/foxy/">
-    <img src="https://img.shields.io/badge/ROS-Foxy-f5792a?style=flat-square&amp;logo=ros&amp;logoColor=white" height="20" alt="ROS Foxy">
-  </a>
   <a href="https://docs.ros.org/en/humble/">
     <img src="https://img.shields.io/badge/ROS-Humble-f5792a?style=flat-square&amp;logo=ros&amp;logoColor=white" height="20" alt="ROS Humble">
   </a>
@@ -41,7 +38,7 @@
 ## Introduction
 
 The **OrbbecSDK ROS2 Wrapper** provides seamless integration of Orbbec cameras with the ROS 2 ecosystem.
- It supports ROS2 **Foxy**, **Humble**, and **Jazzy** distributions.
+ It supports ROS2 **Humble**, **Jazzy**, and **Lyrical** distributions.
 
 - Default branch: **v2-main**
 - For legacy **OpenNI** devices: use the **main** branch

--- a/README_CN.MD
+++ b/README_CN.MD
@@ -12,9 +12,6 @@
 
 <!-- Labels: -->
   <!-- First row: -->
-  <a href="https://docs.ros.org/en/foxy/">
-    <img src="https://img.shields.io/badge/ROS-Foxy-f5792a?style=flat-square&amp;logo=ros&amp;logoColor=white" height="20" alt="ROS Foxy">
-  </a>
   <a href="https://docs.ros.org/en/humble/">
     <img src="https://img.shields.io/badge/ROS-Humble-f5792a?style=flat-square&amp;logo=ros&amp;logoColor=white" height="20" alt="ROS Humble">
   </a>
@@ -40,7 +37,7 @@
 
 ## 简介
 
-OrbbecSDK ROS2 Wrapper 提供 Orbbec 相机与 ROS 2 环境的无缝集成，支持 **ROS2 Foxy、Humble 和 Jazzy** 发行版。
+OrbbecSDK ROS2 Wrapper 提供 Orbbec 相机与 ROS 2 环境的无缝集成，支持 **ROS2 Humble 和 Jazzy** 发行版。
 
 - 默认推荐使用 **v2-main** 分支。
 - 对于旧的 **OpenNI** 设备（v2-main 不支持），请使用 **main** 分支。

--- a/orbbec_camera/CMakeLists.txt
+++ b/orbbec_camera/CMakeLists.txt
@@ -14,6 +14,7 @@ option(INSTALL_UDEV_RULES "Install udev rule for Orbbec cameras" ON)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Wall -Wextra -Werror -Wno-pedantic -Wno-array-bounds)
     add_compile_options(-Wno-error=deprecated-declarations)
+    add_link_options("-Wl,-z,relro,-z,now,-z,defs")
 endif()
 
 # find dependencies

--- a/orbbec_camera/CMakeLists.txt
+++ b/orbbec_camera/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.22)
 project(orbbec_camera)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/orbbec_camera/CMakeLists.txt
+++ b/orbbec_camera/CMakeLists.txt
@@ -292,7 +292,7 @@ install(TARGETS ${PROJECT_NAME} frame_latency start_benchmark multi_save_rgbir A
         LIBRARY DESTINATION lib RUNTIME DESTINATION bin
 )
 
-install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY include/orbbec_camera DESTINATION include/orbbec_camera)
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME}/)
 install(DIRECTORY config DESTINATION share/${PROJECT_NAME}/)
 install(DIRECTORY examples DESTINATION share/${PROJECT_NAME}/)

--- a/orbbec_camera/CMakeLists.txt
+++ b/orbbec_camera/CMakeLists.txt
@@ -13,6 +13,7 @@ option(INSTALL_UDEV_RULES "Install udev rule for Orbbec cameras" ON)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Wall -Wextra -Werror -Wno-pedantic -Wno-array-bounds)
+    add_compile_options(-Wno-error=deprecated-declarations)
 endif()
 
 # find dependencies

--- a/orbbec_camera/CMakeLists.txt
+++ b/orbbec_camera/CMakeLists.txt
@@ -114,26 +114,8 @@ set(COMMON_INCLUDE_DIRS
     $<INSTALL_INTERFACE:include> ${ORBBEC_INCLUDE_DIR} ${OpenCV_INCLUDED_DIRS} ${CMAKE_CURRENT_SOURCE_DIR}/tools
 )
 
-set(COMMON_LIBRARIES
-    ${ORBBEC_SDK_LIBRARIES}
-    ${OpenCV_LIBS}
-    Eigen3::Eigen
-    -lOrbbecSDK
-    -L${ORBBEC_LIBS_DIR}
-    Threads::Threads
-    -lrt
-    -ldw
-    yaml-cpp
-    OpenSSL::Crypto
+set(EXTRA_TARGETS
 )
-if(USE_RK_HW_DECODER)
-    list(APPEND COMMON_LIBRARIES ${RK_MPP_LIBRARIES} ${RGA_LIBRARIES})
-
-endif()
-
-if(USE_NV_HW_DECODER)
-    list(APPEND COMMON_LIBRARIES ${NV_LIBRARIES})
-endif()
 
 set(SOURCE_FILES
   src/d2c_viewer.cpp
@@ -154,15 +136,16 @@ if(USE_RK_HW_DECODER)
     add_definitions(-DUSE_RK_HW_DECODER)
     list(APPEND SOURCE_FILES src/rk_mpp_decoder.cpp)
     list(APPEND COMMON_INCLUDE_DIRS ${RK_MPP_INCLUDE_DIRS} ${RGA_INCLUDE_DIRS})
-    list(APPEND COMMON_LIBRARIES ${RGA_LIBRARIES} ${RK_MPP_LIBRARIES})
+    list(APPEND EXTRA_TARGETS ${RGA_LIBRARIES} ${RK_MPP_LIBRARIES})
     if(NOT RGA_FOUND)
-        list(APPEND COMMON_LIBRARIES -lyuv)
+        list(APPEND EXTRA_TARGETS yuv)
     endif()
 endif()
 
 if(USE_NV_HW_DECODER)
     list(APPEND SOURCE_FILES src/jetson_nv_decoder.cpp)
     list(APPEND COMMON_INCLUDE_DIRS ${JETSON_MULTI_MEDIA_API_INCLUDE_DIR} ${LIBJPEG8B_INCLUDE_DIR})
+    list(APPEND EXTRA_TARGETS ${NV_LIBRARIES})
     # append jetson_multimedia_api source files
     list(
         APPEND
@@ -185,16 +168,42 @@ endif()
 macro(add_orbbec_executable TARGET SOURCE)
     add_executable(${TARGET} ${SOURCE})
     target_include_directories(${TARGET} PUBLIC ${COMMON_INCLUDE_DIRS})
-    target_link_libraries(${TARGET} ${COMMON_LIBRARIES} ${PROJECT_NAME})
-    ament_target_dependencies(${TARGET} ${dependencies})
+    target_link_directories(${TARGET} PRIVATE
+        ${ORBBEC_LIBS_DIR}
+    )
+    target_link_libraries(${TARGET}
+        ${OpenCV_LIBS}
+        ${PROJECT_NAME}
+        OrbbecSDK
+        yaml-cpp
+    )
 endmacro()
 
 # Define library and nodes
 add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
 
-ament_target_dependencies(${PROJECT_NAME} ${dependencies})
-target_include_directories(${PROJECT_NAME} PUBLIC ${COMMON_INCLUDE_DIRS})
-target_link_libraries(${PROJECT_NAME} ${COMMON_LIBRARIES})
+target_include_directories(${PROJECT_NAME} PUBLIC ${COMMON_INCLUDE_DIRS} ${image_publisher_INCLUDE_DIRS})
+target_link_directories(${PROJECT_NAME} PRIVATE ${ORBBEC_LIBS_DIR})
+target_link_libraries(${PROJECT_NAME}
+    ${OpenCV_LIBS}
+    ${orbbec_camera_msgs_TARGETS}
+    ${sensor_msgs_TARGETS}
+    ${std_srvs_TARGETS}
+    ament_index_cpp::ament_index_cpp
+    camera_info_manager::camera_info_manager
+    cv_bridge::cv_bridge
+    diagnostic_updater::diagnostic_updater
+    Eigen3::Eigen
+    image_transport::image_transport
+    message_filters::message_filters
+    OpenSSL::Crypto
+    OrbbecSDK
+    rclcpp::rclcpp
+    rclcpp_components::component
+    tf2::tf2
+    tf2_ros::tf2_ros
+    ${EXTRA_TARGETS}
+)
 
 rclcpp_components_register_node(
     ${PROJECT_NAME} PLUGIN "orbbec_camera::OBCameraNodeDriver" EXECUTABLE orbbec_camera_node
@@ -221,24 +230,57 @@ install(
 
 add_library(frame_latency SHARED tools/frame_latency.cpp)
 target_include_directories(frame_latency PUBLIC ${COMMON_INCLUDE_DIRS})
-target_link_libraries(frame_latency ${COMMON_LIBRARIES})
-ament_target_dependencies(frame_latency ${dependencies})
+target_link_libraries(frame_latency
+    ${orbbec_camera_msgs_TARGETS}
+    ${sensor_msgs_TARGETS}
+    ${tf2_msgs_TARGETS}
+    diagnostic_updater::diagnostic_updater
+    rclcpp::rclcpp
+    rclcpp_components::component
+)
 
 rclcpp_components_register_node(frame_latency PLUGIN "orbbec_camera::FrameLatencyNode" EXECUTABLE frame_latency_node)
 
 add_library(start_benchmark SHARED tools/start_benchmark.cpp)
-target_include_directories(start_benchmark PUBLIC ${COMMON_INCLUDE_DIRS})
-target_link_libraries(start_benchmark ${COMMON_LIBRARIES})
-ament_target_dependencies(start_benchmark ${dependencies})
+target_include_directories(start_benchmark PUBLIC ${COMMON_INCLUDE_DIRS} ${image_publisher_INCLUDE_DIRS})
+target_link_libraries(start_benchmark
+    ${OpenCV_LIBS}
+    ${orbbec_camera_msgs_TARGETS}
+    ${sensor_msgs_TARGETS}
+    ${std_srvs_TARGETS}
+    camera_info_manager::camera_info_manager
+    diagnostic_updater::diagnostic_updater
+    Eigen3::Eigen
+    image_transport::image_transport
+    rclcpp::rclcpp
+    rclcpp_components::component
+    tf2_ros::tf2_ros
+)
 
 rclcpp_components_register_node(
     start_benchmark PLUGIN "orbbec_camera::tools::StartBenchmark" EXECUTABLE start_benchmark_node
 )
 
 add_library(multi_save_rgbir SHARED tools/multi_save_rgbir.cpp src/utils.cpp)
-target_include_directories(multi_save_rgbir PUBLIC ${COMMON_INCLUDE_DIRS})
-target_link_libraries(multi_save_rgbir ${COMMON_LIBRARIES})
-ament_target_dependencies(multi_save_rgbir ${dependencies})
+target_include_directories(multi_save_rgbir PUBLIC ${COMMON_INCLUDE_DIRS} ${image_publisher_INCLUDE_DIRS})
+target_link_directories(multi_save_rgbir PRIVATE ${ORBBEC_LIBS_DIR})
+target_link_libraries(multi_save_rgbir
+    ${OpenCV_LIBS}
+    ${orbbec_camera_msgs_TARGETS}
+    ${sensor_msgs_TARGETS}
+    ${std_srvs_TARGETS}
+    camera_info_manager::camera_info_manager
+    cv_bridge::cv_bridge
+    diagnostic_updater::diagnostic_updater
+    Eigen3::Eigen
+    image_transport::image_transport
+    OpenSSL::Crypto
+    OrbbecSDK
+    rclcpp::rclcpp
+    rclcpp_components::component
+    tf2::tf2
+    tf2_ros::tf2_ros
+)
 
 rclcpp_components_register_node(
     multi_save_rgbir PLUGIN "orbbec_camera::tools::MultiCameraSubscriber" EXECUTABLE multi_save_rgbir_node

--- a/orbbec_camera/CMakeLists.txt
+++ b/orbbec_camera/CMakeLists.txt
@@ -28,6 +28,7 @@ set(dependencies
     camera_info_manager
     image_transport
     image_publisher
+    message_filters
     OpenCV
     orbbec_camera_msgs
     rclcpp

--- a/orbbec_camera/CMakeLists.txt
+++ b/orbbec_camera/CMakeLists.txt
@@ -53,6 +53,10 @@ endforeach()
 find_package(PkgConfig REQUIRED)
 find_package(OpenSSL REQUIRED)
 
+if(message_filters_VERSION VERSION_GREATER_EQUAL 5.0)
+    add_compile_definitions(message_filters_QoS)
+endif()
+
 if(USE_RK_HW_DECODER)
     pkg_search_module(RK_MPP REQUIRED rockchip_mpp)
     if(NOT RK_MPP_FOUND)

--- a/orbbec_camera/CMakeLists.txt
+++ b/orbbec_camera/CMakeLists.txt
@@ -57,6 +57,14 @@ if(message_filters_VERSION VERSION_GREATER_EQUAL 5.0)
     add_compile_definitions(message_filters_QoS)
 endif()
 
+if(image_transport_VERSION VERSION_GREATER_EQUAL 6.4)
+    add_compile_definitions(image_transport_NODE_INTERFACE)
+endif()
+
+if(image_transport_VERSION VERSION_GREATER_EQUAL 6.4)
+    add_compile_definitions(image_transport_QoS)
+endif()
+
 if(USE_RK_HW_DECODER)
     pkg_search_module(RK_MPP REQUIRED rockchip_mpp)
     if(NOT RK_MPP_FOUND)

--- a/orbbec_camera/examples/multi_camera_time_sync/image_sync_example_node.cpp
+++ b/orbbec_camera/examples/multi_camera_time_sync/image_sync_example_node.cpp
@@ -1,6 +1,6 @@
-#include <message_filters/subscriber.h>
-#include <message_filters/sync_policies/approximate_time.h>
-#include <message_filters/synchronizer.h>
+#include <message_filters/subscriber.hpp>
+#include <message_filters/sync_policies/approximate_time.hpp>
+#include <message_filters/synchronizer.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/image.hpp>
 

--- a/orbbec_camera/examples/multi_camera_time_sync/image_sync_example_node.cpp
+++ b/orbbec_camera/examples/multi_camera_time_sync/image_sync_example_node.cpp
@@ -79,13 +79,19 @@ class ImageSyncNode : public rclcpp::Node {
     rclcpp::QoS qos{rclcpp::KeepLast(queue_size_)};
     qos.reliable();
 
+#ifdef message_filters_QoS
+    const rclcpp::QoS qos_prof = qos;
+#else
+    const rmw_qos_profile_t qos_prof = qos.get_rmw_qos_profile();
+#endif
+
     if (sync_topics_.size() == 1) {
       single_sub_ = this->create_subscription<Image>(
           sync_topics_.front(), qos,
           [this](const ImageConstPtr msg) { this->handle_synced_images({msg}); });
     } else {
       for (size_t i = 0; i < sync_topics_.size(); ++i) {
-        subscribers_[i].subscribe(this, sync_topics_[i], qos.get_rmw_qos_profile());
+        subscribers_[i].subscribe(this, sync_topics_[i], qos_prof);
       }
       create_synchronizer();
     }

--- a/orbbec_camera/include/orbbec_camera/d2c_viewer.h
+++ b/orbbec_camera/include/orbbec_camera/d2c_viewer.h
@@ -14,10 +14,10 @@
  * limitations under the License.
  *******************************************************************************/
 #pragma once
-#include <message_filters/subscriber.h>
-#include <message_filters/sync_policies/approximate_time.h>
-#include <message_filters/synchronizer.h>
-#include <message_filters/time_synchronizer.h>
+#include <message_filters/subscriber.hpp>
+#include <message_filters/sync_policies/approximate_time.hpp>
+#include <message_filters/synchronizer.hpp>
+#include <message_filters/time_synchronizer.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <rclcpp/rclcpp.hpp>
 

--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -72,7 +72,6 @@
 #include "orbbec_camera/constants.h"
 #include "orbbec_camera/dynamic_params.h"
 #include "orbbec_camera/d2c_viewer.h"
-#include "magic_enum/magic_enum.hpp"
 #include "orbbec_camera/image_publisher.h"
 #include "orbbec_camera/fps_counter.hpp"
 #include "orbbec_camera/fps_delay_status.hpp"

--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -52,7 +52,6 @@
 #include "libobsensor/ObSensor.hpp"
 
 #include "orbbec_camera_msgs/msg/device_info.hpp"
-#include "orbbec_camera_msgs/msg/depth_filter_param.hpp"
 #include "orbbec_camera_msgs/msg/depth_filter_state.hpp"
 #include "orbbec_camera_msgs/msg/depth_filters_status.hpp"
 #include "orbbec_camera_msgs/srv/get_device_config.hpp"

--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -31,11 +31,11 @@
 #include <opencv2/opencv.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
-#include <tf2_ros/static_transform_broadcaster.h>
-#include <tf2_ros/transform_broadcaster.h>
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2/LinearMath/Vector3.h>
-#include <tf2/LinearMath/Transform.h>
+#include <tf2_ros/static_transform_broadcaster.hpp>
+#include <tf2_ros/transform_broadcaster.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/LinearMath/Vector3.hpp>
+#include <tf2/LinearMath/Transform.hpp>
 #include <std_srvs/srv/set_bool.hpp>
 #include <std_srvs/srv/empty.hpp>
 #include <diagnostic_updater/diagnostic_updater.hpp>

--- a/orbbec_camera/include/orbbec_camera/ob_lidar_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_lidar_node.h
@@ -31,11 +31,11 @@
 #include <sensor_msgs/msg/laser_scan.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
-#include <tf2_ros/static_transform_broadcaster.h>
-#include <tf2_ros/transform_broadcaster.h>
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2/LinearMath/Vector3.h>
-#include <tf2/LinearMath/Transform.h>
+#include <tf2_ros/static_transform_broadcaster.hpp>
+#include <tf2_ros/transform_broadcaster.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/LinearMath/Vector3.hpp>
+#include <tf2/LinearMath/Transform.hpp>
 #include <std_srvs/srv/set_bool.hpp>
 #include <std_srvs/srv/empty.hpp>
 #include <diagnostic_updater/diagnostic_updater.hpp>

--- a/orbbec_camera/include/orbbec_camera/ob_lidar_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_lidar_node.h
@@ -61,7 +61,6 @@
 #include "orbbec_camera/constants.h"
 #include "orbbec_camera/dynamic_params.h"
 #include "orbbec_camera/d2c_viewer.h"
-#include "magic_enum/magic_enum.hpp"
 #include "orbbec_camera/image_publisher.h"
 #include <std_msgs/msg/string.hpp>
 #include <fcntl.h>

--- a/orbbec_camera/include/orbbec_camera/ob_lidar_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_lidar_node.h
@@ -48,10 +48,8 @@
 #include <sensor_msgs/msg/imu.hpp>
 #include "libobsensor/ObSensor.hpp"
 
-#include "orbbec_camera_msgs/msg/device_info.hpp"
 #include "orbbec_camera_msgs/srv/get_device_info.hpp"
 #include "orbbec_camera_msgs/msg/extrinsics.hpp"
-#include "orbbec_camera_msgs/msg/metadata.hpp"
 #include "orbbec_camera_msgs/msg/imu_info.hpp"
 #include "orbbec_camera_msgs/srv/get_int32.hpp"
 #include "orbbec_camera_msgs/srv/get_string.hpp"

--- a/orbbec_camera/include/orbbec_camera/utils.h
+++ b/orbbec_camera/include/orbbec_camera/utils.h
@@ -24,7 +24,6 @@
 #include "sensor_msgs/distortion_models.hpp"
 #include "sensor_msgs/msg/camera_info.hpp"
 #include "orbbec_camera_msgs/msg/extrinsics.hpp"
-#include "magic_enum/magic_enum.hpp"
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <opencv2/opencv.hpp>
 #include <openssl/evp.h>

--- a/orbbec_camera/include/orbbec_camera/utils.h
+++ b/orbbec_camera/include/orbbec_camera/utils.h
@@ -17,7 +17,7 @@
 #pragma once
 #include <ostream>
 #include <Eigen/Dense>
-#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Quaternion.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include "libobsensor/ObSensor.hpp"

--- a/orbbec_camera/package.xml
+++ b/orbbec_camera/package.xml
@@ -17,7 +17,7 @@
   <depend>rclcpp_components</depend>
   <depend>cv_bridge</depend>
   <depend>camera_info_manager</depend>
-  <depend>orbbec_camera_msgs</depend>
+  <depend version_gte="2.8.6">orbbec_camera_msgs</depend>
   <depend>builtin_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>

--- a/orbbec_camera/package.xml
+++ b/orbbec_camera/package.xml
@@ -14,6 +14,7 @@
   <depend>backward_ros</depend>
   <depend>image_transport</depend>
   <depend>image_publisher</depend>
+  <depend>message_filters</depend>
   <depend>rclcpp_components</depend>
   <depend>cv_bridge</depend>
   <depend>camera_info_manager</depend>

--- a/orbbec_camera/src/d2c_viewer.cpp
+++ b/orbbec_camera/src/d2c_viewer.cpp
@@ -30,9 +30,21 @@ D2CViewer::D2CViewer(rclcpp::Node* const node, rmw_qos_profile_t rgb_qos,
                      rmw_qos_profile_t depth_qos, bool use_intra_process)
     : node_(node), logger_(rclcpp::get_logger("d2c_viewer")), is_active_(true) {
   rgb_sub_ = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::Image>>(
-      node_, "color/image_raw", rgb_qos);
+      node_, "color/image_raw",
+#ifdef message_filters_QoS
+      rclcpp::QoS{rclcpp::QoSInitialization::from_rmw(rgb_qos), rgb_qos}
+#else
+      rgb_qos
+#endif
+  );
   depth_sub_ = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::Image>>(
-      node_, "depth/image_raw", depth_qos);
+      node_, "depth/image_raw",
+#ifdef message_filters_QoS
+      rclcpp::QoS{rclcpp::QoSInitialization::from_rmw(depth_qos), depth_qos}
+#else
+      depth_qos
+#endif
+  );
   sync_ = std::make_shared<message_filters::Synchronizer<MySyncPolicy>>(MySyncPolicy(10), *rgb_sub_,
                                                                         *depth_sub_);
   sync_->setMaxIntervalDuration(rclcpp::Duration::from_seconds(1.0));  // 1s

--- a/orbbec_camera/src/image_publisher.cpp
+++ b/orbbec_camera/src/image_publisher.cpp
@@ -36,7 +36,19 @@ image_transport_publisher::image_transport_publisher(rclcpp::Node& node,
                                                      const std::string& topic_name,
                                                      const rmw_qos_profile_t& qos) {
   image_publisher_impl = std::make_shared<image_transport::Publisher>(
-      image_transport::create_publisher(&node, topic_name, qos));
+      image_transport::create_publisher(
+#ifdef image_transport_NODE_INTERFACE
+          image_transport::RequiredInterfaces{node},
+#else
+          &node,
+#endif
+          topic_name,
+#ifdef image_transport_QoS
+          rclcpp::QoS{rclcpp::QoSInitialization::from_rmw(qos), qos}
+#else
+          qos
+#endif
+  ));
 }
 void image_transport_publisher::publish(sensor_msgs::msg::Image::UniquePtr image_ptr) {
   image_publisher_impl->publish(*image_ptr);

--- a/orbbec_camera/src/ob_camera_node.cpp
+++ b/orbbec_camera/src/ob_camera_node.cpp
@@ -452,8 +452,7 @@ void OBCameraNode::publishDepthFiltersStatus() {
     depth_filters_snapshot = depth_filter_list_;
   }
 
-  auto find_depth_filter = [&depth_filters_snapshot,
-                            this](const std::string &filter_name) -> std::shared_ptr<ob::Filter> {
+  auto find_depth_filter = [&depth_filters_snapshot](const std::string &filter_name) -> std::shared_ptr<ob::Filter> {
     const auto normalized_name = normalizeDepthFilterName(filter_name);
     auto it = std::find_if(depth_filters_snapshot.begin(), depth_filters_snapshot.end(),
                            [&normalized_name](const auto &filter) {

--- a/orbbec_camera/src/ob_camera_node.cpp
+++ b/orbbec_camera/src/ob_camera_node.cpp
@@ -27,6 +27,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include <magic_enum/magic_enum.hpp>
 
 #include "orbbec_camera/utils.h"
 #include <filesystem>

--- a/orbbec_camera/src/ob_lidar_node.cpp
+++ b/orbbec_camera/src/ob_lidar_node.cpp
@@ -18,6 +18,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <thread>
 #include <geometry_msgs/msg/transform_stamped.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "orbbec_camera/utils.h"
 #include <filesystem>

--- a/orbbec_camera/src/rk_mpp_decoder.cpp
+++ b/orbbec_camera/src/rk_mpp_decoder.cpp
@@ -16,7 +16,6 @@
 
 #include "orbbec_camera/rk_mpp_decoder.h"
 #include <rclcpp/rclcpp.hpp>
-#include <magic_enum/magic_enum.hpp>
 
 namespace orbbec_camera {
 

--- a/orbbec_camera/tools/multi_save_rgbir.cpp
+++ b/orbbec_camera/tools/multi_save_rgbir.cpp
@@ -5,9 +5,9 @@
 #include <orbbec_camera/utils.h>
 #include "orbbec_camera/ob_camera_node.h"
 #include "orbbec_camera_msgs/msg/metadata.hpp"
-#include <message_filters/subscriber.h>
-#include <message_filters/sync_policies/approximate_time.h>
-#include <message_filters/synchronizer.h>
+#include <message_filters/subscriber.hpp>
+#include <message_filters/sync_policies/approximate_time.hpp>
+#include <message_filters/synchronizer.hpp>
 #include <std_msgs/msg/int32.hpp>
 #include <filesystem>
 #include <regex>

--- a/orbbec_camera/tools/ob_benchmark.cpp
+++ b/orbbec_camera/tools/ob_benchmark.cpp
@@ -3,9 +3,9 @@
 #include <orbbec_camera/ob_camera_node_driver.h>
 #include <orbbec_camera/utils.h>
 #include "orbbec_camera_msgs/msg/metadata.hpp"
-#include <message_filters/subscriber.h>
-#include <message_filters/sync_policies/approximate_time.h>
-#include <message_filters/synchronizer.h>
+#include <message_filters/subscriber.hpp>
+#include <message_filters/sync_policies/approximate_time.hpp>
+#include <message_filters/synchronizer.hpp>
 #include <filesystem>
 
 namespace orbbec_camera {

--- a/orbbec_camera/tools/start_benchmark.cpp
+++ b/orbbec_camera/tools/start_benchmark.cpp
@@ -3,9 +3,9 @@
 #include <orbbec_camera/ob_camera_node_driver.h>
 #include <orbbec_camera/utils.h>
 #include "orbbec_camera_msgs/msg/metadata.hpp"
-#include <message_filters/subscriber.h>
-#include <message_filters/sync_policies/approximate_time.h>
-#include <message_filters/synchronizer.h>
+#include <message_filters/subscriber.hpp>
+#include <message_filters/sync_policies/approximate_time.hpp>
+#include <message_filters/synchronizer.hpp>
 #include <filesystem>
 
 namespace orbbec_camera {

--- a/orbbec_camera_msgs/CMakeLists.txt
+++ b/orbbec_camera_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.22)
 project(orbbec_camera_msgs)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/orbbec_description/CMakeLists.txt
+++ b/orbbec_description/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22)
 project(orbbec_description)
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
This adds support for ROS 2 `lyrical` by mainly replacing `ament_target_dependencies` with the targets for `target_link_libraries`.