### PR TITLE
fix(orbbec_camera): add missing <queue> include in ob_camera_node.h

### DIFF
--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -21,6 +21,7 @@
 #include <cstddef>
 #include <memory>
 #include <optional>
+#include <queue>
 #include <rclcpp/rclcpp.hpp>
 #include <string>
 #include <unordered_map>


### PR DESCRIPTION
### Problem

`orbbec_camera/include/orbbec_camera/ob_camera_node.h` declares three `std::queue` members:

```cpp
std::queue<std::shared_ptr<ob::FrameSet>> color_frame_queue_;        // line 903
std::queue<std::shared_ptr<ob::FrameSet>> left_color_frame_queue_;   // line 910
std::queue<std::shared_ptr<ob::FrameSet>> right_color_frame_queue_;  // line 916
```

but the header never includes `<queue>`.

This only compiles where `<queue>` happens to be pulled in transitively by one of the other includes. The standard does not guarantee that — a standard header is not required to include any other one (`[res.on.headers]`) — so whether the build succeeds depends on the toolchain's header layout rather than on anything in this repository.

### Reproduction

Building `v2-main` (currently ec6bc22) on:

- ROS 2 Humble
- Ubuntu 22.04.5 LTS
- GCC 11.4.0 (`Ubuntu 11.4.0-1ubuntu1~22.04.3`)

fails with:

```
error: 'queue' in namespace 'std' does not name a template type
  903 |   std::queue<std::shared_ptr<ob::FrameSet>> color_frame_queue_;
      |        ^~~~~
note: 'std::queue' is defined in header '<queue>'; this is probably fixable by adding '#include <queue>'
```

### Fix

Adds `#include <queue>` to the existing standard-library include block near the top of the header, preserving the alphabetical ordering already used there (between `<optional>` and `<string>`).

One line, no behavioural change, no risk of regression on toolchains where it already built.
