### PR TITLE
fix: guard depth AE priority readback against unsupported firmware

### DIFF
--- a/orbbec_camera/src/ob_camera_node.cpp
+++ b/orbbec_camera/src/ob_camera_node.cpp
@@ -1591,10 +1591,19 @@ void OBCameraNode::setupDevices() {
     int set_enable_depth_auto_exposure_priority = enable_depth_auto_exposure_priority_ ? 1 : 0;
     TRY_TO_SET_PROPERTY(setIntProperty, OB_PROP_DEPTH_AUTO_EXPOSURE_PRIORITY_INT,
                         set_enable_depth_auto_exposure_priority);
-    RCLCPP_INFO_STREAM(
-        logger_,
-        "Current depth auto exposure priority: "
-            << (device_->getIntProperty(OB_PROP_DEPTH_AUTO_EXPOSURE_PRIORITY_INT) ? "ON" : "OFF"));
+    // Guard the readback: firmware older than the property (e.g. G330 series
+    // < 1.6.00, see issue #190) rejects it with errorCode 2 / status 1005,
+    // which would otherwise throw out of setupDevices and abort device init.
+    try {
+      RCLCPP_INFO_STREAM(
+          logger_,
+          "Current depth auto exposure priority: "
+              << (device_->getIntProperty(OB_PROP_DEPTH_AUTO_EXPOSURE_PRIORITY_INT) ? "ON"
+                                                                                    : "OFF"));
+    } catch (const std::exception &e) {
+      RCLCPP_WARN_STREAM(
+          logger_, "Failed to read depth auto exposure priority, skipping: " << e.what());
+    }
   }
   if (should_apply_launch_config("enable_ir_auto_exposure") &&
       device_->isPropertySupported(OB_PROP_IR_AUTO_EXPOSURE_BOOL, OB_PERMISSION_WRITE)) {

--- a/orbbec_camera/src/ob_camera_node.cpp
+++ b/orbbec_camera/src/ob_camera_node.cpp
@@ -1600,6 +1600,9 @@ void OBCameraNode::setupDevices() {
           "Current depth auto exposure priority: "
               << (device_->getIntProperty(OB_PROP_DEPTH_AUTO_EXPOSURE_PRIORITY_INT) ? "ON"
                                                                                     : "OFF"));
+    } catch (const ob::Error &e) {
+      RCLCPP_WARN_STREAM(logger_, "Failed to read depth auto exposure priority, skipping: "
+                                      << orbbec_camera::formatObErrorWithStatus(e));
     } catch (const std::exception &e) {
       RCLCPP_WARN_STREAM(
           logger_, "Failed to read depth auto exposure priority, skipping: " << e.what());


### PR DESCRIPTION
## Problem

On G330-series cameras with firmware older than 1.6.00, the node crashes at startup and never comes up:

```
[ERROR] [camera.camera]: Failed to set 2052 to 0 in setupDevices at line 1213: Request failed, device response with error, errorCode: 2, msg: , propertyId: 2052 status:1005
[ERROR] [camera.camera]: Failed to setup topics: Request failed, device response with error, errorCode: 2, msg: , propertyId: 2052 status:1005
[ERROR] [camera.camera]: Failed to initialize device (Attempt 1 of 3): ...
...
[ERROR] [camera.camera]: Device initialization failed after 3 attempts.
```

Reproduced on a Gemini 336 (v2.8.6 and current `v2-main` have the same code path). Same failure previously reported in #190 for a Gemini 336L on firmware 1.2.81; it was closed with "upgrade the firmware", but the driver-side fragility remains.

## Cause

Old firmware does not implement `OB_PROP_DEPTH_AUTO_EXPOSURE_PRIORITY_INT` (2052) and rejects it with device errorCode 2 / `OB_ERROR_DEVICE_RESPONSE_ERROR` (1005), while `isPropertySupported()` still reports the property as supported. In `setupDevices()`:

- the **write** goes through `TRY_TO_SET_PROPERTY`, so the rejection is logged and survived (first ERROR line above);
- the **readback** on the next line — `getIntProperty(OB_PROP_DEPTH_AUTO_EXPOSURE_PRIORITY_INT)`, used only to print the "Current depth auto exposure priority" INFO log — is unguarded. The same rejection throws out of `setupDevices()`, aborts all 3 init attempts, and the node ends up with no topics.

## Fix

Wrap the readback in try/catch: log a WARN and continue instead of aborting device init over an informational log line. This mirrors how the same property is already read defensively elsewhere in this file (the config readback path guards `getIntProperty(OB_PROP_DEPTH_AUTO_EXPOSURE_PRIORITY_INT)` with `can_read()` + try/catch).

With this patch, startup on old firmware proceeds normally past the property and all topics come up.
