### PR TITLE
Fix explicit Ethernet camera startup in strict snap environments

### DIFF
--- a/orbbec_camera/src/ob_camera_node_driver.cpp
+++ b/orbbec_camera/src/ob_camera_node_driver.cpp
@@ -376,23 +376,31 @@ void OBCameraNodeDriver::init() {
   net_device_port_ = static_cast<int>(declare_parameter<int>("net_device_port", 0));
   enumerate_net_device_ = declare_parameter<bool>("enumerate_net_device", false);
   uvc_backend_ = declare_parameter<std::string>("uvc_backend", "libuvc");
-  const bool use_explicit_net_device =
-      !enumerate_net_device_ && !net_device_ip_.empty() && net_device_port_ != 0;
+  const bool use_explicit_net_device = !net_device_ip_.empty() && net_device_port_ != 0;
   device_access_mode_str_ = declare_parameter<std::string>("device_access_mode", "Default");
   device_access_mode_ = stringToAccessMode(device_access_mode_str_);
   RCLCPP_INFO_STREAM(logger_, "Device access mode: " << device_access_mode_str_ << " ("
                                                      << device_access_mode_ << ")");
   if (!use_explicit_net_device) {
-    if (uvc_backend_ == "libuvc") {
-      ctx_->setUvcBackendType(OB_UVC_BACKEND_TYPE_LIBUVC);
-      RCLCPP_INFO_STREAM(logger_, "Set UVC backend to " << uvc_backend_);
-    } else if (uvc_backend_ == "v4l2") {
-      ctx_->setUvcBackendType(OB_UVC_BACKEND_TYPE_V4L2);
-      RCLCPP_INFO_STREAM(logger_, "Set UVC backend to " << uvc_backend_);
-    } else {
-      ctx_->setUvcBackendType(OB_UVC_BACKEND_TYPE_LIBUVC);
+    try {
+      if (uvc_backend_ == "libuvc") {
+        ctx_->setUvcBackendType(OB_UVC_BACKEND_TYPE_LIBUVC);
+        RCLCPP_INFO_STREAM(logger_, "Set UVC backend to " << uvc_backend_);
+      } else if (uvc_backend_ == "v4l2") {
+        ctx_->setUvcBackendType(OB_UVC_BACKEND_TYPE_V4L2);
+        RCLCPP_INFO_STREAM(logger_, "Set UVC backend to " << uvc_backend_);
+      } else {
+        ctx_->setUvcBackendType(OB_UVC_BACKEND_TYPE_LIBUVC);
+        RCLCPP_WARN_STREAM(
+            logger_, "Unsupported uvc_backend '" << uvc_backend_ << "', using default libuvc");
+      }
+    } catch (const ob::Error &e) {
+      if (!enumerate_net_device_ || e.getStatus() != OB_ERROR_ITEM_NOT_FOUND) {
+        throw;
+      }
       RCLCPP_WARN_STREAM(logger_,
-                         "Unsupported uvc_backend '" << uvc_backend_ << "', using default libuvc");
+                         "USB backend is unavailable; continuing with network device enumeration: "
+                             << orbbec_camera::formatObErrorWithStatus(e));
     }
   }
   ctx_->enableNetDeviceEnumeration(enumerate_net_device_);

--- a/orbbec_camera/src/ob_camera_node_driver.cpp
+++ b/orbbec_camera/src/ob_camera_node_driver.cpp
@@ -376,20 +376,24 @@ void OBCameraNodeDriver::init() {
   net_device_port_ = static_cast<int>(declare_parameter<int>("net_device_port", 0));
   enumerate_net_device_ = declare_parameter<bool>("enumerate_net_device", false);
   uvc_backend_ = declare_parameter<std::string>("uvc_backend", "libuvc");
+  const bool use_explicit_net_device =
+      !enumerate_net_device_ && !net_device_ip_.empty() && net_device_port_ != 0;
   device_access_mode_str_ = declare_parameter<std::string>("device_access_mode", "Default");
   device_access_mode_ = stringToAccessMode(device_access_mode_str_);
   RCLCPP_INFO_STREAM(logger_, "Device access mode: " << device_access_mode_str_ << " ("
                                                      << device_access_mode_ << ")");
-  if (uvc_backend_ == "libuvc") {
-    ctx_->setUvcBackendType(OB_UVC_BACKEND_TYPE_LIBUVC);
-    RCLCPP_INFO_STREAM(logger_, "Set UVC backend to " << uvc_backend_);
-  } else if (uvc_backend_ == "v4l2") {
-    ctx_->setUvcBackendType(OB_UVC_BACKEND_TYPE_V4L2);
-    RCLCPP_INFO_STREAM(logger_, "Set UVC backend to " << uvc_backend_);
-  } else {
-    ctx_->setUvcBackendType(OB_UVC_BACKEND_TYPE_LIBUVC);
-    RCLCPP_WARN_STREAM(logger_,
-                       "Unsupported uvc_backend '" << uvc_backend_ << "', using default libuvc");
+  if (!use_explicit_net_device) {
+    if (uvc_backend_ == "libuvc") {
+      ctx_->setUvcBackendType(OB_UVC_BACKEND_TYPE_LIBUVC);
+      RCLCPP_INFO_STREAM(logger_, "Set UVC backend to " << uvc_backend_);
+    } else if (uvc_backend_ == "v4l2") {
+      ctx_->setUvcBackendType(OB_UVC_BACKEND_TYPE_V4L2);
+      RCLCPP_INFO_STREAM(logger_, "Set UVC backend to " << uvc_backend_);
+    } else {
+      ctx_->setUvcBackendType(OB_UVC_BACKEND_TYPE_LIBUVC);
+      RCLCPP_WARN_STREAM(logger_,
+                         "Unsupported uvc_backend '" << uvc_backend_ << "', using default libuvc");
+    }
   }
   ctx_->enableNetDeviceEnumeration(enumerate_net_device_);
   device_changed_callback_id_ = ctx_->registerDeviceChangedCallback(


### PR DESCRIPTION
    This PR fixes the startup failure reported in issue #199 for explicit Ethernet camera configurations in strict-confinement snap environments.
    When `enumerate_net_device` is disabled and `net_device_ip` / `net_device_port` are provided, the camera is expected to connect through Ethernet directly. In this mode, initializing the UVC backend is unnecessary and can trigger USB PAL access in restricted snap environments, causing startup failure.
    The change skips UVC backend setup for explicit Ethernet devices while preserving the existing UVC backend behavior for USB devices and network enumeration mode.