### PR TITLE
fix(femto): preserve native YUYV shadows and runtime controls

### DIFF
--- a/orbbec_camera/CMakeLists.txt
+++ b/orbbec_camera/CMakeLists.txt
@@ -122,6 +122,7 @@ if(USE_NV_HW_DECODER)
 endif()
 
 set(SOURCE_FILES
+  src/color_conversion.cpp
   src/d2c_viewer.cpp
   src/dynamic_params.cpp
   src/image_publisher.cpp
@@ -263,6 +264,18 @@ install(TARGETS list_devices_node list_depth_work_mode_node list_camera_profile_
 if(BUILD_TESTING)
     find_package(ament_lint_auto REQUIRED)
     ament_lint_auto_find_test_dependencies()
+    add_executable(dynamic_params_test
+                   test/dynamic_params_test.cpp src/dynamic_params.cpp src/ros_param_backend.cpp)
+    target_include_directories(dynamic_params_test PRIVATE ${COMMON_INCLUDE_DIRS})
+    ament_target_dependencies(dynamic_params_test rclcpp)
+    add_test(NAME dynamic_params_test COMMAND dynamic_params_test)
+    add_executable(color_conversion_test
+                   test/color_conversion_test.cpp src/color_conversion.cpp)
+    target_include_directories(color_conversion_test PRIVATE ${COMMON_INCLUDE_DIRS})
+    add_test(NAME color_conversion_test COMMAND color_conversion_test)
+    add_executable(property_transaction_test test/property_transaction_test.cpp)
+    target_include_directories(property_transaction_test PRIVATE ${COMMON_INCLUDE_DIRS})
+    add_test(NAME property_transaction_test COMMAND property_transaction_test)
 endif()
 
 ament_export_include_directories(include)

--- a/orbbec_camera/include/orbbec_camera/color_conversion.h
+++ b/orbbec_camera/include/orbbec_camera/color_conversion.h
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Orbbec 3D Technology, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace orbbec_camera {
+
+bool yuyvFullRangeToRgb(const uint8_t* source, size_t source_size, uint8_t* destination,
+                        size_t destination_size, uint32_t width, uint32_t height);
+
+}  // namespace orbbec_camera

--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -255,6 +255,8 @@ class OBCameraNode {
 
   void setupDevices();
 
+  void setupRuntimeColorControls();
+
   void loadConfigJson();
 
   void captureInitialRosParameters();

--- a/orbbec_camera/include/orbbec_camera/property_transaction.h
+++ b/orbbec_camera/include/orbbec_camera/property_transaction.h
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Orbbec 3D Technology, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+#pragma once
+
+#include <exception>
+#include <stdexcept>
+#include <string>
+
+namespace orbbec_camera {
+
+template <typename T, typename Getter, typename Setter>
+T setPropertyWithVerifiedRollback(const T &requested, Getter getter, Setter setter) {
+  const T previous = getter();
+  try {
+    setter(requested);
+    const T applied = getter();
+    if (applied != requested) {
+      throw std::runtime_error("property readback does not match requested value");
+    }
+    return applied;
+  } catch (...) {
+    const auto original_error = std::current_exception();
+    try {
+      setter(previous);
+      if (getter() != previous) {
+        throw std::runtime_error("rollback readback does not match previous value");
+      }
+    } catch (const std::exception &rollback_error) {
+      throw std::runtime_error("property update failed and rollback failed: " +
+                               std::string(rollback_error.what()));
+    } catch (...) {
+      throw std::runtime_error("property update failed and rollback failed with unknown error");
+    }
+    std::rethrow_exception(original_error);
+  }
+}
+
+}  // namespace orbbec_camera

--- a/orbbec_camera/src/color_conversion.cpp
+++ b/orbbec_camera/src/color_conversion.cpp
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Orbbec 3D Technology, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+#include "orbbec_camera/color_conversion.h"
+
+#include <algorithm>
+
+namespace orbbec_camera {
+namespace {
+
+uint8_t clampToByte(int value) { return static_cast<uint8_t>(std::clamp(value, 0, 255)); }
+
+void yuvToRgb(uint8_t y, int u, int v, uint8_t* rgb) {
+  rgb[0] = clampToByte(static_cast<int>(y) + 359 * v / 256);
+  rgb[1] = clampToByte(static_cast<int>(y) - (88 * u + 183 * v) / 256);
+  rgb[2] = clampToByte(static_cast<int>(y) + 454 * u / 256);
+}
+
+}  // namespace
+
+bool yuyvFullRangeToRgb(const uint8_t* source, size_t source_size, uint8_t* destination,
+                        size_t destination_size, uint32_t width, uint32_t height) {
+  const size_t pixel_count = static_cast<size_t>(width) * height;
+  if (source == nullptr || destination == nullptr || width == 0 || height == 0 || width % 2 != 0 ||
+      source_size < pixel_count * 2 || destination_size < pixel_count * 3) {
+    return false;
+  }
+
+  for (size_t source_offset = 0, destination_offset = 0; source_offset < pixel_count * 2;
+       source_offset += 4, destination_offset += 6) {
+    const int u = static_cast<int>(source[source_offset + 1]) - 128;
+    const int v = static_cast<int>(source[source_offset + 3]) - 128;
+    yuvToRgb(source[source_offset], u, v, destination + destination_offset);
+    yuvToRgb(source[source_offset + 2], u, v, destination + destination_offset + 3);
+  }
+  return true;
+}
+
+}  // namespace orbbec_camera

--- a/orbbec_camera/src/dynamic_params.cpp
+++ b/orbbec_camera/src/dynamic_params.cpp
@@ -21,6 +21,17 @@ Parameters::Parameters(rclcpp::Node *node)
     : node_(node), logger_(node_->get_logger()), params_backend_(node) {
   params_backend_.addOnSetParametersCallback(
       [this](const std::vector<rclcpp::Parameter> &parameters) {
+        if (parameters.size() > 1) {
+          for (const auto &parameter : parameters) {
+            const auto functions = param_functions_.find(parameter.get_name());
+            if (functions != param_functions_.end() && !functions->second.empty()) {
+              rcl_interfaces::msg::SetParametersResult result;
+              result.successful = false;
+              result.reason = "runtime hardware parameters must be changed one at a time";
+              return result;
+            }
+          }
+        }
         for (const auto &parameter : parameters) {
           if (param_functions_.find(parameter.get_name()) != param_functions_.end()) {
             auto functions = param_functions_[parameter.get_name()];
@@ -29,7 +40,19 @@ Parameters::Parameters(rclcpp::Node *node)
                                                        << " can not be changed in runtime.");
             } else {
               for (const auto &func : param_functions_[parameter.get_name()]) {
-                func(parameter);
+                try {
+                  func(parameter);
+                } catch (const std::exception &e) {
+                  rcl_interfaces::msg::SetParametersResult result;
+                  result.successful = false;
+                  result.reason = parameter.get_name() + ": " + e.what();
+                  return result;
+                } catch (...) {
+                  rcl_interfaces::msg::SetParametersResult result;
+                  result.successful = false;
+                  result.reason = parameter.get_name() + ": unknown error";
+                  return result;
+                }
               }
             }
           }

--- a/orbbec_camera/src/ob_camera_node.cpp
+++ b/orbbec_camera/src/ob_camera_node.cpp
@@ -15,6 +15,8 @@
  *******************************************************************************/
 
 #include "orbbec_camera/ob_camera_node.h"
+#include "orbbec_camera/color_conversion.h"
+#include "orbbec_camera/property_transaction.h"
 #include <rclcpp/rclcpp.hpp>
 #include <thread>
 #include <geometry_msgs/msg/transform_stamped.hpp>
@@ -915,6 +917,54 @@ void OBCameraNode::clean() noexcept {
 
   RCLCPP_DEBUG_STREAM(logger_, "OBCameraNode cleanup complete");
   cleaning_.store(false);
+}
+
+void OBCameraNode::setupRuntimeColorControls() {
+  auto register_int_control = [this](const std::string &name, int &cached, OBPropertyID property) {
+    int *cached_value = &cached;
+    parameters_->setParam(name, rclcpp::ParameterValue(cached),
+                          [this, name, cached_value, property](const rclcpp::Parameter &parameter) {
+                            if (!device_->isPropertySupported(property, OB_PERMISSION_READ_WRITE)) {
+                              throw std::runtime_error(name + " is not supported by this device");
+                            }
+                            const int requested = static_cast<int>(parameter.as_int());
+                            const auto range = device_->getIntPropertyRange(property);
+                            if (requested < range.min || requested > range.max) {
+                              throw std::runtime_error("value " + std::to_string(requested) +
+                                                       " is outside [" + std::to_string(range.min) +
+                                                       ", " + std::to_string(range.max) + "]");
+                            }
+                            std::lock_guard<decltype(device_lock_)> lock(device_lock_);
+                            *cached_value = setPropertyWithVerifiedRollback<int>(
+                                requested, [this, property]() {
+                                  return device_->getIntProperty(property);
+                                },
+                                [this, property](int value) {
+                                  device_->setIntProperty(property, value);
+                                });
+                          });
+  };
+
+  parameters_->setParam(
+      "enable_color_auto_exposure", rclcpp::ParameterValue(enable_color_auto_exposure_),
+      [this](const rclcpp::Parameter &parameter) {
+        if (!device_->isPropertySupported(OB_PROP_COLOR_AUTO_EXPOSURE_BOOL,
+                                          OB_PERMISSION_READ_WRITE)) {
+          throw std::runtime_error("color auto exposure is not supported by this device");
+        }
+        const bool requested = parameter.as_bool();
+        std::lock_guard<decltype(device_lock_)> lock(device_lock_);
+        enable_color_auto_exposure_ = setPropertyWithVerifiedRollback<bool>(
+            requested,
+            [this]() {
+              return device_->getBoolProperty(OB_PROP_COLOR_AUTO_EXPOSURE_BOOL);
+            },
+            [this](bool value) {
+              device_->setBoolProperty(OB_PROP_COLOR_AUTO_EXPOSURE_BOOL, value);
+            });
+      });
+  register_int_control("color_exposure", color_exposure_, OB_PROP_COLOR_EXPOSURE_INT);
+  register_int_control("color_gain", color_gain_, OB_PROP_COLOR_GAIN_INT);
 }
 
 void OBCameraNode::setupDevices() {
@@ -4798,6 +4848,7 @@ void OBCameraNode::setupTopics() {
     loadConfigJson();
     syncConfigJsonApplicationConfig();
     setupDevices();
+    setupRuntimeColorControls();
     setupDepthPostProcessFilter();
     setupColorPostProcessFilter();
     setupIrPostProcessFilter();
@@ -6478,6 +6529,25 @@ bool OBCameraNode::decodeColorFrameToBuffer(const std::shared_ptr<ob::Frame> &fr
 
   if (!has_subscriber) {
     return false;
+  }
+
+  if (pid_ == FEMTO_BOLT_PID && frame->getFormat() == OB_FORMAT_YUYV) {
+    auto video_frame = frame->as<ob::ColorFrame>();
+    if (!video_frame) {
+      RCLCPP_ERROR_STREAM(logger_, "Failed to access Femto Bolt YUYV color frame");
+      return false;
+    }
+    const size_t buffer_capacity = stream_index == COLOR_LEFT    ? rgb_buffer_left_size_
+                                   : stream_index == COLOR_RIGHT ? rgb_buffer_right_size_
+                                                                 : rgb_buffer_size_;
+    if (!yuyvFullRangeToRgb(static_cast<const uint8_t *>(video_frame->getData()),
+                            video_frame->getDataSize(), buffer, buffer_capacity,
+                            video_frame->getWidth(), video_frame->getHeight())) {
+      RCLCPP_ERROR_STREAM(logger_, "Failed to convert Femto Bolt full-range YUYV frame");
+      return false;
+    }
+    RCLCPP_DEBUG_ONCE(logger_, "Using full-range YUYV conversion for Femto Bolt color");
+    return true;
   }
 
   std::shared_ptr<JPEGDecoder> decoder;

--- a/orbbec_camera/src/ros_service.cpp
+++ b/orbbec_camera/src/ros_service.cpp
@@ -878,10 +878,13 @@ void OBCameraNode::setExposureCallback(const std::shared_ptr<SetInt32::Request>&
         break;
       case OB_STREAM_COLOR:
       case OB_STREAM_COLOR_LEFT:
-      case OB_STREAM_COLOR_RIGHT:
-        device_->setIntProperty(OB_PROP_COLOR_EXPOSURE_INT, request->data);
-        color_exposure_ = device_->getIntProperty(OB_PROP_COLOR_EXPOSURE_INT);
-        break;
+      case OB_STREAM_COLOR_RIGHT: {
+        const auto result =
+            node_->set_parameter(rclcpp::Parameter("color_exposure", request->data));
+        response->success = result.successful;
+        response->message = result.reason;
+        return;
+      }
       default:
         RCLCPP_ERROR(logger_, "%s NOT a video stream", __FUNCTION__);
         break;
@@ -943,6 +946,13 @@ void OBCameraNode::setGainCallback(const std::shared_ptr<SetInt32 ::Request>& re
   auto stream = stream_index.first;
   OBPropertyID prop_id = OB_PROP_IR_GAIN_INT;
   try {
+    if (stream == OB_STREAM_COLOR || stream == OB_STREAM_COLOR_LEFT ||
+        stream == OB_STREAM_COLOR_RIGHT) {
+      const auto result = node_->set_parameter(rclcpp::Parameter("color_gain", request->data));
+      response->success = result.successful;
+      response->message = result.reason;
+      return;
+    }
     switch (stream) {
       case OB_STREAM_IR_LEFT:
       case OB_STREAM_IR_RIGHT:
@@ -1205,6 +1215,14 @@ void OBCameraNode::setAutoExposureCallback(
   auto stream = stream_index.first;
   OBPropertyID prop_id = OB_PROP_IR_AUTO_EXPOSURE_BOOL;
   try {
+    if (stream == OB_STREAM_COLOR || stream == OB_STREAM_COLOR_LEFT ||
+        stream == OB_STREAM_COLOR_RIGHT) {
+      const auto result =
+          node_->set_parameter(rclcpp::Parameter("enable_color_auto_exposure", request->data));
+      response->success = result.successful;
+      response->message = result.reason;
+      return;
+    }
     switch (stream) {
       case OB_STREAM_IR_LEFT:
       case OB_STREAM_IR_RIGHT:

--- a/orbbec_camera/test/color_conversion_test.cpp
+++ b/orbbec_camera/test/color_conversion_test.cpp
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Orbbec 3D Technology, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+#include <array>
+#include <cstdint>
+#include <stdexcept>
+
+#include "orbbec_camera/color_conversion.h"
+
+namespace {
+
+void require(bool condition) {
+  if (!condition) {
+    throw std::runtime_error("color conversion contract failed");
+  }
+}
+
+}  // namespace
+
+int main() {
+  {
+    const std::array<uint8_t, 4> yuyv{8, 128, 16, 128};
+    std::array<uint8_t, 6> rgb{};
+    require(
+        orbbec_camera::yuyvFullRangeToRgb(yuyv.data(), yuyv.size(), rgb.data(), rgb.size(), 2, 1));
+    require((rgb == std::array<uint8_t, 6>{8, 8, 8, 16, 16, 16}));
+  }
+
+  {
+    const std::array<uint8_t, 4> yuyv{0, 128, 255, 128};
+    std::array<uint8_t, 6> rgb{};
+    require(
+        orbbec_camera::yuyvFullRangeToRgb(yuyv.data(), yuyv.size(), rgb.data(), rgb.size(), 2, 1));
+    require((rgb == std::array<uint8_t, 6>{0, 0, 0, 255, 255, 255}));
+  }
+
+  {
+    const std::array<uint8_t, 4> yuyv{100, 255, 100, 0};
+    std::array<uint8_t, 6> rgb{};
+    require(
+        orbbec_camera::yuyvFullRangeToRgb(yuyv.data(), yuyv.size(), rgb.data(), rgb.size(), 2, 1));
+    require(rgb[0] == 0);
+    require(rgb[1] > 140);
+    require(rgb[2] == 255);
+  }
+
+  {
+    std::array<uint8_t, 4> yuyv{};
+    std::array<uint8_t, 6> rgb{};
+    require(
+        !orbbec_camera::yuyvFullRangeToRgb(yuyv.data(), yuyv.size(), rgb.data(), rgb.size(), 1, 1));
+    require(!orbbec_camera::yuyvFullRangeToRgb(yuyv.data(), 3, rgb.data(), rgb.size(), 2, 1));
+    require(!orbbec_camera::yuyvFullRangeToRgb(yuyv.data(), yuyv.size(), rgb.data(), 5, 2, 1));
+  }
+  return 0;
+}

--- a/orbbec_camera/test/dynamic_params_test.cpp
+++ b/orbbec_camera/test/dynamic_params_test.cpp
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Orbbec 3D Technology, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "orbbec_camera/dynamic_params.h"
+
+namespace {
+
+void require(bool condition) {
+  if (!condition) {
+    throw std::runtime_error("dynamic parameter contract failed");
+  }
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<rclcpp::Node>("dynamic_params_test");
+
+  {
+    orbbec_camera::Parameters parameters(node.get());
+    int64_t applied = 0;
+    parameters.setParam("runtime_value", rclcpp::ParameterValue(int64_t{0}),
+                        [&applied](const rclcpp::Parameter &parameter) {
+                          const auto requested = parameter.as_int();
+                          if (requested < 0) {
+                            throw std::runtime_error("negative values are unsupported");
+                          }
+                          applied = requested;
+                        });
+
+    const auto accepted = node->set_parameter(rclcpp::Parameter("runtime_value", 7));
+    require(accepted.successful);
+    require(applied == 7);
+    require(node->get_parameter("runtime_value").as_int() == 7);
+
+    int64_t other_applied = 0;
+    parameters.setParam("other_runtime_value", rclcpp::ParameterValue(int64_t{0}),
+                        [&other_applied](const rclcpp::Parameter &parameter) {
+                          other_applied = parameter.as_int();
+                        });
+    const auto atomic_rejected = node->set_parameters_atomically(
+        {rclcpp::Parameter("runtime_value", 8), rclcpp::Parameter("other_runtime_value", 9)});
+    require(!atomic_rejected.successful);
+    require(atomic_rejected.reason.find("one at a time") != std::string::npos);
+    require(applied == 7);
+    require(other_applied == 0);
+    require(node->get_parameter("runtime_value").as_int() == 7);
+    require(node->get_parameter("other_runtime_value").as_int() == 0);
+
+    const auto rejected = node->set_parameter(rclcpp::Parameter("runtime_value", -1));
+    require(!rejected.successful);
+    require(rejected.reason.find("negative values are unsupported") != std::string::npos);
+    require(applied == 7);
+    require(node->get_parameter("runtime_value").as_int() == 7);
+  }
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/orbbec_camera/test/property_transaction_test.cpp
+++ b/orbbec_camera/test/property_transaction_test.cpp
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Orbbec 3D Technology, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+#include "orbbec_camera/property_transaction.h"
+
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+void require(bool condition) {
+  if (!condition) {
+    throw std::runtime_error("property transaction test failed");
+  }
+}
+
+}  // namespace
+
+int main() {
+  using orbbec_camera::setPropertyWithVerifiedRollback;
+
+  int state = 1;
+  const auto getter = [&state]() { return state; };
+  const auto setter = [&state](int value) { state = value; };
+  require(setPropertyWithVerifiedRollback(5, getter, setter) == 5);
+  require(state == 5);
+
+  state = 1;
+  const auto reject_requested = [&state](int value) { state = value == 5 ? 2 : value; };
+  try {
+    setPropertyWithVerifiedRollback(5, getter, reject_requested);
+    require(false);
+  } catch (const std::runtime_error &error) {
+    require(std::string(error.what()).find("readback") != std::string::npos);
+  }
+  require(state == 1);
+
+  state = 1;
+  const auto reject_all = [&state](int) { state = 2; };
+  try {
+    setPropertyWithVerifiedRollback(5, getter, reject_all);
+    require(false);
+  } catch (const std::runtime_error &error) {
+    require(std::string(error.what()).find("rollback failed") != std::string::npos);
+  }
+  require(state == 2);
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

- preserve Femto Bolt shadow detail when publishing native, uncompressed YUYV as RGB8
- apply color auto-exposure, exposure, and gain changes to hardware at runtime
- route the matching ROS services through the same validated parameter/property transaction
- reject invalid requests before side effects and verify both property writes and rollback readback

## Root cause

The Femto Bolt raw YUYV path currently selects the SDK's `FORMAT_YUYV_TO_RGB888` conversion. In SDK v2 that path converts through I420 using the limited-range BT.601 matrix, including the Y-16 offset. The Femto Bolt's native YUYV stream contains meaningful shadow samples below 16, so the conversion clips most of a dim scene to black.

Selecting RGB888 is not a lossless workaround on Femto Bolt: its Linux RGB888 profile is synthesized from MJPG, so JPEG artifacts already exist before ROS receives the image.

This change keeps the behavior device-scoped. Only Femto Bolt's native YUYV-to-RGB publication uses the small full-range BT.601 conversion; other cameras and formats retain the SDK converter.

## Verification

Container build and the focused tests pass:

- `color_conversion_test`
- `dynamic_params_test`
- `property_transaction_test`

Physical Femto Bolt CL8654103RE, firmware 1.1.3, USB 3.1, 1280x720 at 30 Hz, identical manual exposure 300 and gain 64:

| path | mean luma | p50 | p99 | near-black fraction |
|---|---:|---:|---:|---:|
| current v2-main | 2.0863 | 0.00 | 34.67 | 0.911686 |
| patched | 8.0568 | 5.33 | 44.67 | 0.028336 |

Neither capture clipped highlights. The patched stream sustained 30.0-30.12 Hz.

Runtime control was exercised without restarting the driver through both interfaces:

1. enable AE by parameter and service;
2. wait for convergence;
3. disable AE by parameter and service;
4. set exposure 300 and gain 64 by parameter and service;
5. read both values back from hardware.

An out-of-range exposure request (301; hardware range 1-300) was rejected and hardware remained at 300.

## End-to-end result

The original converter A/B disabled SDK color undistortion to isolate the range defect. The separate YUYV border bug is fixed by https://github.com/orbbec/OrbbecSDK_v2/pull/184.

With both patches and color undistortion enabled, the full Femto Bolt RGB-D/IMU to ORB-SLAM3 to GPU-mapping path ran on hardware. Pure-green border pixels fell from 25,056 to zero. Splatograph mapped 1,552 frames without sequence gaps, middleware-reported loss, or a worker failure and flushed a finite, non-empty 175-vertex PLY.
