### PR TITLE
ignore stream parameters for streams that are not available

### DIFF
--- a/orbbec_camera/src/ob_camera_node.cpp
+++ b/orbbec_camera/src/ob_camera_node.cpp
@@ -4372,7 +4372,11 @@ void OBCameraNode::setupDefaultImageFormat() {
 void OBCameraNode::getParameters() {
   setAndGetNodeParameter<std::string>(camera_name_, "camera_name", "camera");
   camera_link_frame_id_ = camera_name_ + "_link";
-  for (auto stream_index : IMAGE_STREAMS) {
+  for (const auto &stream_index : IMAGE_STREAMS) {
+    if (!stream_name_.count(stream_index)) {
+      continue;
+    }
+
     std::string param_name = stream_name_[stream_index] + "_width";
     setAndGetNodeParameter(width_[stream_index], param_name, 0);
     param_name = stream_name_[stream_index] + "_height";
@@ -4410,7 +4414,7 @@ void OBCameraNode::getParameters() {
     setAndGetNodeParameter<bool>(enable_undistortion_[stream_index], param_name, false);
   }
 
-  for (auto stream_index : IMAGE_STREAMS) {
+  for (const auto &stream_index : IMAGE_STREAMS) {
     depth_aligned_frame_id_[stream_index] = optical_frame_id_[COLOR];
   }
 
@@ -4419,6 +4423,10 @@ void OBCameraNode::getParameters() {
   setAndGetNodeParameter<bool>(enable_sync_output_accel_gyro_, "enable_sync_output_accel_gyro",
                                false);
   for (const auto &stream_index : HID_STREAMS) {
+    if (!stream_name_.count(stream_index)) {
+      continue;
+    }
+
     std::string param_name = stream_name_[stream_index] + "_qos";
     setAndGetNodeParameter<std::string>(imu_qos_[stream_index], param_name, "default");
     param_name = "enable_" + stream_name_[stream_index];


### PR DESCRIPTION
For streams that are not provided by the camera, e.g. `OB_STREAM_LIDAR` for the Orbbec, the node creates parameters such as:
```
enable_
enable__undistortion
```
and:
```
_camera_info_qos
_flip
_format
_fps
_height
_mirror
_optical_frame_id
_qos
_rotation
_width
```
because `stream_name_[stream_index]` will just return a default constructed empty string.

This PR adds check for `stream_name_.contains(stream_index)` in order to avoid this creating of clutter parameters.

Note that I created this PR against the `lyrical` branch.